### PR TITLE
Fix main content size

### DIFF
--- a/src/stylesheets/app.scss
+++ b/src/stylesheets/app.scss
@@ -75,5 +75,6 @@ code {
   position: relative;
   text-align: center;
   z-index: 1;
-  width: calc(100vw - $navbar-width);
+  width: 100%;
+  height: 100%;
 }


### PR DESCRIPTION
Currently the main-content div doesn't span the width of the page. I've added 2 styles to ensure that it will always be 100% height and 100% width. Setting `width: 100%` means it will take up as much space as it can. Doing this will enable us to hide the navbar if we want to, e.g. on mobile views