### PR TITLE
Add Linting and Testing Github Action Workflow for Continuous Integration

### DIFF
--- a/.github/disabled-workflows/tests.yml
+++ b/.github/disabled-workflows/tests.yml
@@ -1,6 +1,6 @@
 name: Tests
 
-on: push
+on: [push, pull_request]
 
 jobs:
   test:

--- a/.github/disabled-workflows/tests.yml
+++ b/.github/disabled-workflows/tests.yml
@@ -1,0 +1,18 @@
+name: Tests
+
+on: push
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v2
+      - name: Set up Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: 10
+      - run: npm ci
+      - run: npm run build --if-present
+      - run: npm test

--- a/.github/workflows/eslint_and_prettier.yml
+++ b/.github/workflows/eslint_and_prettier.yml
@@ -1,6 +1,6 @@
 name: ESLint and Prettier
 
-on: push
+on: [push, pull_request]
 
 jobs:
   run-linters:

--- a/.github/workflows/eslint_and_prettier.yml
+++ b/.github/workflows/eslint_and_prettier.yml
@@ -1,0 +1,24 @@
+name: ESLint and Prettier
+
+on: push
+
+jobs:
+  run-linters:
+    name: Run linters
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v2
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: 10
+
+      # ESLint and Prettier must be in `package.json`
+      - name: Install Node.js dependencies
+        run: npm ci
+
+      - name: Run linters
+        run: npm run lint

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
-# assignment1
-
-SOFTENG701 Group5 - Assignment1
+# SOFTENG701 Group5 - Assignment1
+| CI                  | Status   |
+| ------------------- | -------- |
+| Tests               | Disabled |
+| ESLint and Prettier |  [![ESLint and Prettier](https://github.com/SoftEng701-Group5/assignment1/actions/workflows/eslint_and_prettier.yml/badge.svg?branch=main)](https://github.com/SoftEng701-Group5/assignment1/actions/workflows/eslint_and_prettier.yml) |
+| Build and Deploy    | [![Build and Deploy](https://github.com/SoftEng701-Group5/assignment1/actions/workflows/build_and_deploy.yml/badge.svg?branch=main)](https://github.com/SoftEng701-Group5/assignment1/actions/workflows/build_and_deploy.yml) |
 
 ## Workflow
 


### PR DESCRIPTION
Two more Github Action workflow is added - these checks are **now ran in every PR**
1. ESLint and Prettier to be checked upon every PR
2. Tests to be run upon every PR. But currently `.github/disabled-workflows/tests.yml` File is currently placed in the `disabled-workflows` folder as I am waiting on Daniel D's PR for setting up tests. I will move this to be a part of the CI workflow once he's merged.

I have also updated the README.md file to include some CI status badges :D so it looks more like an open-source project lol.