### PR TITLE
Add enter hotkey to add new task 

### DIFF
--- a/src/components/NewTask.jsx
+++ b/src/components/NewTask.jsx
@@ -75,6 +75,17 @@ export default function NewTask() {
     resetValues();
   }
 
+  /**
+   * Called for any keypress while user is focused on the button
+   * If the key pressed is enter, the supplied clickHandler function is called
+   * @param event Keypress event
+   */
+  function handleKeyPress(event) {
+    if (event.key === "Enter") {
+      handleAddNewTask();
+    }
+  }
+
   return (
     <div className="newtask-container">
       <AddButton onClick={() => setDisplay(true)} />
@@ -82,6 +93,7 @@ export default function NewTask() {
         dismissOnClickOutside
         onCancel={handleCancelNewTask}
         show={display}
+        handleKeyPress={handleKeyPress}
       >
         <div className="">
           <div className="hBox">

--- a/src/components/global/Modal.jsx
+++ b/src/components/global/Modal.jsx
@@ -15,6 +15,7 @@ export default function Modal({
   onCancel,
   children,
   show,
+  handleKeyPress,
 }) {
   if (!show) {
     return null;
@@ -31,7 +32,10 @@ export default function Modal({
         }
       }}
     >
-      <div className="modalContainer">{children}</div>
+      {/* eslint-disable-next-line */}
+      <div className="modalContainer" onKeyPress={handleKeyPress} tabIndex="0">
+        {children}
+      </div>
     </div>,
     modalRoot
   );

--- a/src/components/global/Modal.jsx
+++ b/src/components/global/Modal.jsx
@@ -9,6 +9,7 @@ const modalRoot = document.querySelector("#modal-root");
  * @param onCancel function to call when the modal is cancelled
  * @param children Variable used to represent all the children of the modal component
  * @param show boolean used to show or hide the modal
+ * @param handleKeyPress function to handle key presses when inside the modal
  */
 export default function Modal({
   dismissOnClickOutside,


### PR DESCRIPTION
**Describe the issue**
When the modal is open, the user cannot use Enter to fire off the add new task functionality - the user must click the button to do so. 

**Describe the solution**
Added a onKeyPress listener on the newTaskModal to listen to the keyCode "Enter".
