### PR TITLE
Fixed month test on DateTime.test.jsx

### DIFF
--- a/src/tests/components/DateTime.test.jsx
+++ b/src/tests/components/DateTime.test.jsx
@@ -25,7 +25,7 @@ test("Renders DateTime correctly", () => {
   const d = new Date();
   const wordDay = DAYS[d.getDay()];
   expect(container).toHaveTextContent(d.getDate());
-  expect(container).toHaveTextContent(d.getMonth());
+  expect(container).toHaveTextContent(d.getMonth() + 1);
   expect(container).toHaveTextContent(d.getFullYear());
   expect(container).toHaveTextContent(wordDay);
 });


### PR DESCRIPTION
**Describe the issue**

![image](https://user-images.githubusercontent.com/48905868/113802739-566d3280-97af-11eb-8337-308bc16e4d94.png)
This expect fails, and has the potential to pass depending on time
The container can only have months from 1-12 while getMonth() can only produce the value between values between 0-11
The test can pass depending on minutes/seconds

**Describe the solution**
Modified test by shifting the expected value by 1 so that the string can be searched with the right month
Resolves #241 
