### PR TITLE
Fixed the unclickable subtask dropdowns in the home screen task list.

### DIFF
--- a/src/components/global/Task/Task.jsx
+++ b/src/components/global/Task/Task.jsx
@@ -13,13 +13,7 @@ function Task(props) {
 
   return (
     <div className={`task${isExpanded ? "--expanded" : ""}`}>
-      <div
-        className={`task__header${selected ? "--selected" : ""}`}
-        onClick={onClick}
-        onKeyDown={onClick}
-        role="button"
-        tabIndex="0"
-      >
+      <div className={`task__header${selected ? "--selected" : ""}`}>
         <div
           className={`task__checkbox${isChecked ? "--checked" : ""}`}
           onClick={handleCheckBoxClick}
@@ -29,7 +23,13 @@ function Task(props) {
           tabIndex="0"
           aria-checked={isChecked}
         />
-        <span className={`task__title${isChecked ? "--checked" : ""}`}>
+        <span
+          className={`task__title${isChecked ? "--checked" : ""}`}
+          onClick={onClick}
+          onKeyDown={onClick}
+          role="button"
+          tabIndex="0"
+        >
           {name}
         </span>
         <RightChevron handleOnClick={handleIconClick} isRotated={isExpanded} />


### PR DESCRIPTION
**Describe the issue**
This PR resolves issue #213. Currently on the home screen task list, the dropdowns to view subtasks of tasks are unclickable. Attempting to click on the dropdown chevrons results in the page navigating to the dashboard view. This is the intended function when clicking a task, but should not occur when clicking a task's dropdown. This problem also applies to the checkboxes on the tasks (they are also unclickable). 

**Describe the solution**
The problem was that the parent div of the checkbox and chevron was clickable (in `Task.jsx`)
* Moved the on click functionality of the parent div to one of its children, the span containing the task name. This makes it so the checkbox, the task, and the chevron are all clickable.