### PR TITLE
Consistent naming of "Description" and "Notes" for a task

### DIFF
--- a/src/components/current-task/CurrentTaskNotes.jsx
+++ b/src/components/current-task/CurrentTaskNotes.jsx
@@ -28,7 +28,7 @@ function CurrentTaskNotes(props) {
       }`}
     >
       <div className="current-task-notes__header">
-        <span className="current-task-notes__title">Discription</span>
+        <span className="current-task-notes__title">Description</span>
         <RightChevron handleOnClick={handleIconClick} isRotated={isExpanded} />
       </div>
       <form

--- a/src/components/current-task/CurrentTaskNotes.jsx
+++ b/src/components/current-task/CurrentTaskNotes.jsx
@@ -28,7 +28,7 @@ function CurrentTaskNotes(props) {
       }`}
     >
       <div className="current-task-notes__header">
-        <span className="current-task-notes__title">Notes</span>
+        <span className="current-task-notes__title">Discription</span>
         <RightChevron handleOnClick={handleIconClick} isRotated={isExpanded} />
       </div>
       <form


### PR DESCRIPTION
---
name: Pull Request to fix issue #190
about: change the "Notes" title to "Description" in the task.
title: 'Change the Notes to Description '
labels:
assignees: 'Jigao Zeng'
---

**Describe the issue**
When adding a task it asks for a description but when displaying a task it displays what was written under notes. This cause inconsistency in naming and can confuse user

**Describe the solution**
Change the title of "Notes" to "Description" to make it consistent.
