### PR TITLE
Fix timer input padding

### DIFF
--- a/src/components/current-task/TimerConfig.jsx
+++ b/src/components/current-task/TimerConfig.jsx
@@ -15,13 +15,20 @@ const IntervalInput = (props) => {
   const [secondsValue, setSecondsValue] = useState("00");
 
   const handleMinutesChanged = (val) => {
-    setMinutesValue(val);
-    onTimeChangeHandler(val, secondsValue);
+    // For minutes, include 0 padding but also allow for more than double digits
+    if (val.charAt(0) === "0" || val.length < 2) {
+      setMinutesValue(`00${val}`.slice(-2));
+      onTimeChangeHandler(`00${val}`.slice(-2), secondsValue);
+    } else {
+      setMinutesValue(val);
+      onTimeChangeHandler(val, secondsValue);
+    }
   };
 
   const handleSecondsChanged = (val) => {
-    setSecondsValue(val);
-    onTimeChangeHandler(minutesValue, val);
+    // Seconds should be restricted to only two digits
+    setSecondsValue(`00${val}`.slice(-2));
+    onTimeChangeHandler(minutesValue, `00${val}`.slice(-2));
   };
 
   return (

--- a/src/components/current-task/TimerConfig.jsx
+++ b/src/components/current-task/TimerConfig.jsx
@@ -78,6 +78,13 @@ function TimerConfig(props) {
   // Helper function to check if inputs are integers or not, if not, the state is set to NaN
   const validated = (val, field) => {
     if (/^\d+$/.test(val)) {
+      if (field.includes("Seconds") && parseInt(val, 10) > 59) {
+        setTimerConfigValues((prevState) => ({
+          ...prevState,
+          [field]: NaN,
+        }));
+        return false;
+      }
       setTimerConfigValues((prevState) => ({
         ...prevState,
         [field]: parseInt(val, 10),


### PR DESCRIPTION
**Describe the issue**
When there is a time input with less than 2 digits, there is no 0 padding in front of the field, e.g. "1" should be "01", or if the field's empty there should be "00".

**Describe the solution**
- For minute fields, pad the string with "00" and slice off the 0s when needed. Minutes are not restricted to only two digits.
- For second fields, pad and slice like above, but the field is restricted to only two digits.

**Additional implementation**
Restrict the seconds field to only have values of 59 or less. Any input values above this range will be deemed invalid.
